### PR TITLE
adds basic router and page stubs

### DIFF
--- a/src/app/finetune/page.tsx
+++ b/src/app/finetune/page.tsx
@@ -1,0 +1,4 @@
+
+export default function Page() {
+  return <h1>Finetunes</h1>
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,14 @@
 "use client"
 
 import * as React from 'react'
-import './globals.css'
+import Link from 'next/link'
 import { Inter } from 'next/font/google'
 import { Login } from "@/components"
 import Wallet from 'ethereumjs-wallet'
 
 import { WalletContext } from '@/utils'
+
+import './globals.css'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -20,7 +22,18 @@ export default function RootLayout({
     <html lang="en">
       <WalletContext.Provider value={{ wallet }}>
         <body className={inter.className}>
-          <nav className="flex justify-end">
+          <nav className="flex justify-between items-center w-full">
+            <div className='flex items-center'>
+              <Link href='/'>
+                <h1 className='uppercase font-bold text-xl mr-24'>ai.repo</h1>
+              </Link>
+              <Link href='/finetune'>
+                <p className='uppercase text-md mr-4'>finetune</p>
+              </Link>
+              <Link href='/model'>
+                <p className='uppercase text-md mr-4'>model</p>
+              </Link>
+            </div>
             <Login setWallet={setWallet} />
           </nav>
           {children}

--- a/src/app/model/page.tsx
+++ b/src/app/model/page.tsx
@@ -1,0 +1,5 @@
+
+
+export default function Page() {
+  return <h1>Models</h1>
+}

--- a/src/components/login/index.tsx
+++ b/src/components/login/index.tsx
@@ -22,7 +22,11 @@ export function Login({
   const login = useLogin()
   const db = usePolybase()
 
-  const windowWidth = window ? window.innerWidth : 1000
+  let windowWidth = 1000
+
+  if (window) {
+    windowWidth = window.innerWidth
+  }
 
   const sidePanelProps = useSpring({
     config: {


### PR DESCRIPTION
<img width="1422" alt="Screenshot 2023-06-13 at 9 22 25 AM" src="https://github.com/dbcfd/ai-repo/assets/123114362/9bc67c96-6767-4737-ae83-d06c606cdf48">


Adds basic nav and page structure, just stubbed them for now. I have wires below to show basics of what I'm thinking for the pages, let me know if you think about it differently.

Finetunes -
![finetune](https://github.com/dbcfd/ai-repo/assets/123114362/44147b43-38e4-45ff-9df2-66b8a7ab7bdf)

Models-
![model](https://github.com/dbcfd/ai-repo/assets/123114362/92feb94f-b2e2-4697-b18e-53893e26d109)


I think creation of both finetune/model can be done from the same view that you use to interact with existing ones.
Models can be spawned from any finetune.
Users can search and filter for both, and models can be filtered by finetune.
Submit finetune and view submission progress/results can happen from a finetune detail pane/page(TBD).